### PR TITLE
feat/reimplement json format configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,14 +125,22 @@ A json object hash with severities as keys and arrays of audit json data used to
 
 ```json
 { 
-  "critical": [
-    {
-
-    }
-  ],
+  "critical": [],
   "high": [],
   "moderate": [],
-  "low": [],
+  "low": [
+    { 
+      "title": "Prototype Pollution",
+       "moduleName": "yargs-parser",
+       "vulnerableVersions": "<13.1.2 || >=14.0.0 <15.0.1 || >=16.0.0 <18.1.2",
+       "patchedVersions": ">=13.1.2 <14.0.0 || >=15.0.1 <16.0.0 || >=18.1.2",
+       "overview":
+        "Affected versions of `yargs-parser` are vulnerable to prototype pollution. Arguments are not properly sanitized, allowing an attacker to modify the prototype of `Object`, causing the addition or modification of an existing property that will exist on all objects.  \nParsing the argument `--foo.__proto__.bar baz'` adds a `bar` property with value `baz` to all objects. This is only exploitable if attackers have control over the arguments being passed to `yargs-parser`.\n",
+       "recommendation": "Upgrade to versions 13.1.2, 15.0.1, 18.1.1 or later.",
+       "url": "https://npmjs.com/advisories/1500",
+       "severity": "low" 
+    }
+  ],
   "info": [] 
 }
 ```

--- a/README.md
+++ b/README.md
@@ -9,17 +9,12 @@ $ npm install pretty-npm-audit
 
 ## Params
 
-- `dirPath`
+- `dirPath` (String)
 
    Directory path of the project to audit 
 (Defaults current directory)
 
-- `environment`
-
-   Environment of the project 
-(Currently Unimplemented)
-
-- `sort`
+- `sort` (String)
 
    Sort output audits ascending from least to most serverity or descending from most to least severity.
 
@@ -27,6 +22,17 @@ $ npm install pretty-npm-audit
 
       asc - (String) Ascending severity low to high 
       dsc - (String) Descending severity high to low (Default)
+
+- `jsonPretty` (Boolean)
+
+  Return a json object hash with severities as keys and arrays of audit strings in pretty tabular format. The keys are sorted depending if sort key is provided.
+  (Default: false)
+
+- `json` (Boolean)
+    
+    Return a json object hash with severities as keys and arrays of audit data used to populate pretty tables in json format. The keys are sorted depending if sort key is provided.
+  (Default: false)
+
 
 - `debug`
 
@@ -41,7 +47,6 @@ const prettyNpmAudit = require("pretty-audit");
 
 prettyNpmAudit({
     dirPath: "./vulnerable-package",
-    sort: "asc",
   });
   
 
@@ -80,7 +85,7 @@ const prettyNpmAudit = require("pretty-audit");
 
 prettyNpmAudit({
     dirPath: "./vulnerable-package",
-    json: true
+    jsonPretty: true,
   });
   
 
@@ -94,6 +99,37 @@ A json object hash with severities as keys and arrays of audit strings similar t
 ```json
 { 
   "critical": [],
+  "high": [],
+  "moderate": [],
+  "low": [],
+  "info": [] 
+}
+```
+
+### Example 3
+```js
+const prettyNpmAudit = require("pretty-audit");
+
+prettyNpmAudit({
+    dirPath: "./vulnerable-package",
+    json: true,
+  });
+  
+
+const results = await prettyNpmAudit.audit();
+```
+
+This produces:
+
+A json object hash with severities as keys and arrays of audit json data used to populate the pretty tables described in example 1 and 2. The root level serverity keys can be sorted depending if sort key is provided.
+
+```json
+{ 
+  "critical": [
+    {
+
+    }
+  ],
   "high": [],
   "moderate": [],
   "low": [],

--- a/index.js
+++ b/index.js
@@ -3,9 +3,9 @@ const { parserModule, commandsModule, logger } = require("./src/modules");
 
 const useConfig = {
   dirPath: "./",
-  environment: "ci",
   debug: false,
   json: false,
+  jsonPretty: false,
 };
 
 function config() {
@@ -44,6 +44,7 @@ function audit() {
           payload: completePayload,
           sort: useConfig.sort,
           json: useConfig.json,
+          jsonPretty: useConfig.jsonPretty,
         });
         resolve(data);
       } catch (e) {
@@ -63,25 +64,28 @@ function prettyAudit(...args) {
     if (commands) {
       const {
         dirPath,
-        environment,
         sort,
         debug,
         json,
+        jsonPretty,
       } = commandsModule.parseCommands(commands);
 
+      if(json !== undefined && jsonPretty !== undefined) {
+        throw new Error('Please provide one option between json and jsonPretty');
+      }
+
       useConfig.dirPath = dirPath === undefined ? useConfig.dirPath : dirPath;
-      useConfig.environment =
-        environment === undefined ? useConfig.environment : environment;
       useConfig.sort = sort === undefined ? useConfig.sort : sort;
       useConfig.debug = debug === undefined ? useConfig.debug : debug;
       useConfig.json = json === undefined ? useConfig.json : json;
+      useConfig.jsonPretty = jsonPretty === undefined ? useConfig.jsonPretty : jsonPretty;
     }
   }
 
   // Reset config if changed
   logger.setConfig({
-    enabled: useConfig.debug,
-    prettyPrint: useConfig.debug,
+    enabled: !!useConfig.debug,
+    prettyPrint: !!useConfig.debug,
   });
 }
 

--- a/src/modules/commands.module.js
+++ b/src/modules/commands.module.js
@@ -4,13 +4,14 @@ const fs = require("fs");
  * Parses commands into supported ones and ignores the rest
  * @param {Object} commands
  * @param {String} commands.dirPath
- * @param {String} commands.environment
  * @param {String} commands.sort
  * @param {Boolean} commands.debug
+ * @param {Boolean} commands.json
+ * @param {Boolean} commands.jsonPretty
  */
 function parseCommands(commands) {
   if (commands && typeof commands === "object") {
-    const { dirPath, environment, sort, debug, json } = commands;
+    const { dirPath, sort, debug, json, jsonPretty } = commands;
     // TODO: Go through and do param validation e.g make sure dirpath is an actual path
   
     if (dirPath && !fs.existsSync(dirPath)) {
@@ -19,10 +20,10 @@ function parseCommands(commands) {
 
     return {
       dirPath,
-      environment,
       sort,
       debug,
       json,
+      jsonPretty,
     };
   }
   return {};

--- a/src/modules/parser.module.js
+++ b/src/modules/parser.module.js
@@ -35,7 +35,7 @@ function buildTable({
   return data;
 }
 
-function parse({ payload, sort, json }) {
+function parse({ payload, sort, json, jsonPretty }) {
   const { metadata, advisories } = payload;
 
   const { vulnerabilities } = metadata;
@@ -66,8 +66,18 @@ function parse({ payload, sort, json }) {
 
   const advisoryNumbers = Object.keys(advisories);
 
+  // TODO: Cleanup how we create this tables so that we don't have to have
+  // two identical root level objects
   // Defaults to dsc - highest to lowest priority
-  const advisoryTables = {
+  const advisoryTablesJson = {
+    critical: [],
+    high: [],
+    moderate: [],
+    low: [],
+    info: [],
+  };
+
+  const advisoryTablesJsonPretty = {
     critical: [],
     high: [],
     moderate: [],
@@ -99,7 +109,7 @@ function parse({ payload, sort, json }) {
       severity,
     });
 
-    const message = buildTable({
+    const cleanJson = {
       title,
       moduleName,
       vulnerableVersions,
@@ -108,20 +118,22 @@ function parse({ payload, sort, json }) {
       recommendation,
       url,
       severity,
-    });
+    };
 
-    advisoryTables[severity].push(message);
+    advisoryTablesJson[severity].push(cleanJson);
+
+    advisoryTablesJsonPretty[severity].push(buildTable(cleanJson));
   });
 
   // Defaults to dsc - highest to lowest priority
-  let sortedTables = advisoryTables;
+  let sortedTables = json === true ? advisoryTablesJson : advisoryTablesJsonPretty;
 
   if (sort && sort === "asc") {
     sortedTables = arraysModule.reverseObjectByKeys(sortedTables);
   }
 
   // Return all tables squashed into a string of tables
-  if (!json) {
+  if (!jsonPretty && !json) {
     return arraysModule.objectToString(sortedTables);
   }
 


### PR DESCRIPTION
## Description

- Implement `json` config. Allows ability for users to be able to customize the response json into what they need 
- Implement `jsonPretty` config. It does what json used to do which returns a json hash of severities with arrays of pretty tables of the audit.

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

It was tested locally by changing all different types of configs and making sure they are work as desired

**Test Configuration**:
* Firmware version:
* Hardware:
* Toolchain:
* SDK:

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings